### PR TITLE
fix: readme assets parser

### DIFF
--- a/modules/modules-sync/runtime/utils/index.ts
+++ b/modules/modules-sync/runtime/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./promise";
 export * from "./module-loader";
+export * from "./parser";

--- a/modules/modules-sync/runtime/utils/module-loader.ts
+++ b/modules/modules-sync/runtime/utils/module-loader.ts
@@ -1,6 +1,6 @@
 import { createResolver, type useLogger } from "nuxt/kit";
 import { existsSync, promises as fsp } from "node:fs";
-import { executeWithConcurrency } from ".";
+import { executeWithConcurrency, parseReadmeAssets } from ".";
 import defu from "defu";
 import * as yml from "js-yaml";
 import { ofetch } from "ofetch";
@@ -153,6 +153,8 @@ export class ModuleLoader {
       async (mod) => {
         const dbModule = await moduleStorage.getModule(mod.name);
 
+        const readme = mod.readme ? parseReadmeAssets(mod.readme, mod.repo) : null;
+
         const moduleData: Module = {
           created_at: dbModule?.created_at ?? new Date(),
           updated_at: new Date(),
@@ -167,7 +169,7 @@ export class ModuleLoader {
           interface: mod.interface || [],
           stars: mod.repoInfo?.stargazers_count ?? null,
           downloads: mod.npmInfo?.downloads ?? null,
-          readme: mod.readme,
+          readme,
           official: mod.official,
           sponsor: mod.sponsor,
         };

--- a/modules/modules-sync/runtime/utils/parser.ts
+++ b/modules/modules-sync/runtime/utils/parser.ts
@@ -1,0 +1,41 @@
+export function parseReadmeAssets(content: string, repo: string): string {
+  if (!content) return content;
+
+  const [owner, repoName] = repo.split("/");
+  const baseUrl = `https://raw.githubusercontent.com/${owner}/${repoName}`;
+  const branch = "main"; // Default to main branch when using repo slug
+
+  // Replace markdown image/link patterns: ![alt](path) or [text](path)
+  // Updated regex to match relative paths without ./ prefix
+  const markdownRegex = /(!?\[.*?\])\((?!http|#)([^)]+)\)/g;
+  return content.replace(markdownRegex, (match, linkText, path) => {
+    // Don't replace absolute URLs or anchors
+    if (path.startsWith("http") || path.startsWith("#")) {
+      return match;
+    }
+
+    // If the path doesn't start with a dot or slash, add a slash
+    const normalizedPath =
+      path.startsWith(".") || path.startsWith("/") ? path.replace(/^\//, "") : path;
+
+    const absolutePath = `${baseUrl}/${branch}/${normalizedPath}`;
+    return `${linkText}(${absolutePath})`;
+  });
+
+  // // Replace HTML tags with src or href attributes
+  // const htmlRegex =
+  //   /(<(?:img|a|link|script|source)[^>]*?(?:src|href)=["'])(?!http|#)([^"']*?)(["'][^>]*?>)/gi;
+  // processedContent = processedContent.replace(htmlRegex, (match, tagStart, path, tagEnd) => {
+  //   // Don't replace absolute URLs or anchors
+  //   if (path.startsWith("http") || path.startsWith("#")) {
+  //     return match;
+  //   }
+
+  //   // If the path doesn't start with a dot or slash, add a slash
+  //   const normalizedPath =
+  //     path.startsWith(".") || path.startsWith("/") ? path.replace(/^\//, "") : path;
+
+  //   const absolutePath = `${baseUrl}/${branch}/${normalizedPath}`;
+  //   return `${tagStart}${absolutePath}${tagEnd}`;
+  // });
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Enhance the module loader utility by adding a parser that converts relative asset paths into raw GitHub links.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
