### PR TITLE
docs: update module-management.md to add new main entrypoint on local source

### DIFF
--- a/content/docs/2.interfaces/2.module-management.md
+++ b/content/docs/2.interfaces/2.module-management.md
@@ -233,7 +233,7 @@ The `source` field can have different structures depending on the type:
   path: '/absolute/path/to/module',
   watchDir?: string | string[], // Optional directories to watch for changes
   installCommand?: string | string[], // Optional commands to run during installation
-  main: '/path/to/file', // Optional entrypoint file to be initiate by the cli
+  main?: '/path/to/file', // Optional entrypoint file to be initiate by the cli
   ignoreCache?: boolean
 }
 ```

--- a/content/docs/2.interfaces/2.module-management.md
+++ b/content/docs/2.interfaces/2.module-management.md
@@ -233,6 +233,7 @@ The `source` field can have different structures depending on the type:
   path: '/absolute/path/to/module',
   watchDir?: string | string[], // Optional directories to watch for changes
   installCommand?: string | string[], // Optional commands to run during installation
+  main: '/path/to/file', // Optional entrypoint file to be initiate by the cli
   ignoreCache?: boolean
 }
 ```


### PR DESCRIPTION
<!---
☝️ PR Adding the possibility to use one another entrypoint on LocalSource.
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With this feature you can now start a projet antelope with others entrypoint.
For example:

```
(package.json)

"scripts": {
  "dev": "ajs project run -w --inspect",
  "migrate": "ajs project run -w --inspect --env MIGRATION"
}
```

```
(antelope.json)

"modules": {"YOUR-LOCAL-PORJECT": {}},
"environments": {
  "MIGRATION": {
    "modules": {
      "YOUR-LOCAL-PORJECT": {
        "source": {
           "main": "dist/migrate.js"
         }
     },
     ...
  }
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
