### PR TITLE
docs: sync site with current core + interface APIs (v1.3.0)

### DIFF
--- a/content/docs/2.concepts/4.configuration.md
+++ b/content/docs/2.concepts/4.configuration.md
@@ -105,9 +105,12 @@ Point to a module on your local filesystem. The core watches the specified direc
   path: "./modules/my-module",      // Relative path to the module
   main: "custom-entry.js",          // Custom entry point (optional)
   watchDir: ["src", "lib"],         // Directories to watch (optional, string or string[])
-  installCommand: "npm run build"   // Command to run after install (optional, string or string[])
+  installCommand: "npm run build",  // Command to run after install (optional, string or string[])
+  reloadCommand: "npm run build"    // Command to run on hot reload instead of installCommand (optional, string or string[])
 }
 ```
+
+When set, `reloadCommand` runs in place of `installCommand` during a hot reload, letting you configure a faster command (for example, a build that skips dependency installation).
 
 ### Package Source
 
@@ -144,7 +147,8 @@ Load a module directly from a folder without any compilation step. This source t
   type: "local-folder",
   path: "./modules/my-module",
   watchDir: "src",                  // optional
-  installCommand: "npm install"     // optional
+  installCommand: "npm install",    // optional
+  reloadCommand: "npm run build"    // runs instead of installCommand on hot reload (optional)
 }
 ```
 

--- a/content/docs/2.concepts/5.logging.md
+++ b/content/docs/2.concepts/5.logging.md
@@ -96,7 +96,7 @@ Keys are matched against channel names exactly. A key ending in `*` acts as a pr
 
 ### Date Format
 
-The `dateFormat` field accepts a date format string (e.g., `"yyyy-MM-dd HH:mm:ss"`). Supported tokens: `yyyy`, `yy`, `MM`, `M`, `dd`, `d`, `HH`, `H`, `mm`, `m`, `ss`, `s`, `SSS`.
+The `dateFormat` field accepts a date format string (default: `"yyyy-MM-dd HH:mm:ss"`). Supported tokens: `yyyy`, `MM`, `dd`, `HH`, `mm`, `ss` (all values are formatted in UTC).
 
 ::tip
 Start with `"main": "info"` and lower individual channels to `"debug"` only when you need to troubleshoot a specific subsystem. Selective filtering keeps your log output clean during normal operation.

--- a/content/docs/3.module-development/3.testing.md
+++ b/content/docs/3.module-development/3.testing.md
@@ -91,13 +91,13 @@ Helper files and fixtures that do not match the test pattern are not executed as
 
 During testing, the framework enables stub mode by default. Stub mode enforces strict interface resolution so that unimplemented interfaces fail loudly instead of silently returning undefined.
 
-- `InterfaceFunction` calls reject with "Interface not implemented" unless a loaded module provides the implementation
-- `RegisteringProxy.register()` throws an error if no module handles the registration
+- `InterfaceFunction` calls reject with "Interface function called without implementation in test environment" unless a loaded module provides the implementation
+- `RegisteringProxy.register()` throws the same error if no module handles the registration
 
 This behavior forces you to explicitly load all required modules in your test configuration. Tests become isolated and predictable because every dependency must be declared upfront.
 
 ::warning
-If a test fails with "Interface not implemented", check that the module providing that interface is listed in your test configuration's `modules` section.
+If a test fails with "Interface function called without implementation in test environment", check that the module providing that interface is listed in your test configuration's `modules` section.
 ::
 
 ## Writing Tests

--- a/content/docs/4.guides/2.database.md
+++ b/content/docs/4.guides/2.database.md
@@ -152,14 +152,14 @@ class User extends Table.with(HashModifier, EncryptionModifier) {
 export { User };
 ```
 
-## Creating a Database Schema Instance
+## Registering a Database Schema
 
-Before your models can interact with the database, you must create a schema instance. The `CreateDatabaseSchemaInstance` function initializes the schema that your tables are registered under.
+Before your models can interact with the database, you must register the schema. The `RegisterSchema` function builds the schema definition from all tables registered under the given schema id and provisions it through the database adapter.
 
 ```typescript [src/db/schema.ts]
-import { CreateDatabaseSchemaInstance } from "@antelopejs/interface-database-decorators";
+import { RegisterSchema } from "@antelopejs/interface-database-decorators";
 
-await CreateDatabaseSchemaInstance("main");
+await RegisterSchema("main");
 ```
 
 The schema name passed here must match the schema name used in your `@RegisterTable` decorators. Call this function once during module initialization (for example, in the module's `construct` function). The function is async, so make sure to `await` it.

--- a/content/docs/4.guides/5.full-stack-tutorial.md
+++ b/content/docs/4.guides/5.full-stack-tutorial.md
@@ -293,7 +293,7 @@ The Data API definition replaces dozens of lines of manual route handlers. The f
 The module entry point ties everything together. The `construct` function initializes the database schema and registers interface implementations. The `start` function begins listening for HTTP requests. Importing the route and data-api files ensures they are registered with the framework.
 
 ```typescript [src/index.ts]
-import { CreateDatabaseSchemaInstance } from "@antelopejs/interface-database-decorators";
+import { RegisterSchema } from "@antelopejs/interface-database-decorators";
 
 // Import tables to register them
 import "./db/tables/user";
@@ -304,8 +304,8 @@ import "./routes/auth";
 import "./data-api/tasks";
 
 export async function construct(): Promise<void> {
-  // Create the database schema
-  await CreateDatabaseSchemaInstance("main");
+  // Register the database schema
+  await RegisterSchema("main");
 }
 
 export function start(): void {
@@ -321,7 +321,7 @@ export async function destroy(): Promise<void> {
 }
 ```
 
-The import statements at the top ensure that all `@RegisterTable`, `Controller`, and `@RegisterDataController()` declarations execute and register their targets with the framework. The `CreateDatabaseSchemaInstance("main")` call initializes the database schema that both tables reference. This module consumes interfaces from other modules but does not export any of its own, so there is no `ImplementInterface` call.
+The import statements at the top ensure that all `@RegisterTable`, `Controller`, and `@RegisterDataController()` declarations execute and register their targets with the framework. The `RegisterSchema("main")` call initializes the database schema that both tables reference. This module consumes interfaces from other modules but does not export any of its own, so there is no `ImplementInterface` call.
 
 #### Configure the project
 

--- a/content/docs/4.guides/6.troubleshooting.md
+++ b/content/docs/4.guides/6.troubleshooting.md
@@ -59,4 +59,4 @@ Verify that all required modules are listed in `antelope.config.ts` and that eac
 
 - [Architecture](/docs/get-started/architecture) — How the core handles errors during lifecycle phases
 - [Testing](/docs/module-development/testing) — Test configuration and stub mode
-- [Configuration](/docs/guides/configuration) — Module configuration reference
+- [Configuration](/docs/concepts/configuration) — Module configuration reference

--- a/content/docs/5.cli/1.introduction.md
+++ b/content/docs/5.cli/1.introduction.md
@@ -57,13 +57,13 @@ Each top-level command contains subcommands that perform specific tasks. For exa
 
 These options apply to any command:
 
-| Option              | Description                                              |
-|---------------------|----------------------------------------------------------|
-| `-v, --version`     | Display the CLI version number                           |
-| `--verbose`         | Enable verbose logging channels (repeatable for more detail) |
-| `--help`            | Show help for the current command                        |
+| Option                 | Description                                              |
+|------------------------|----------------------------------------------------------|
+| `-v, --version`        | Display the CLI version number                           |
+| `--verbose [=channels]`| Enable verbose (TRACE level) logging                     |
+| `--help`               | Show help for the current command                        |
 
-The `--verbose` flag can be repeated to increase the logging detail level. A single `--verbose` enables standard verbose output; adding more increases granularity.
+By default `--verbose` enables TRACE-level logging for all channels. To scope it to specific channels, pass a comma-separated list, for example `--verbose=cli.command,resolution`.
 
 ## Getting Help
 

--- a/content/docs/5.cli/2.project.md
+++ b/content/docs/5.cli/2.project.md
@@ -49,7 +49,7 @@ ajs project dev [options]
 | `-c, --concurrency <number>` | Number of modules to load in parallel       |
 | `--inspect [host:port]`   | Enable the Node.js debugger                    |
 | `-i, --interactive`       | Enable REPL mode for live interaction          |
-| `--verbose`               | Enable verbose logging channels                |
+| `--verbose [=channels]`   | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
 
 **Examples:**
 
@@ -95,7 +95,7 @@ ajs project build [options]
 |----------------------------|------------------------------------------------|
 | `-p, --project <path>`    | Path to the project folder                     |
 | `-e, --env <environment>` | Environment name to build for                  |
-| `--verbose`               | Enable verbose logging channels                |
+| `--verbose [=channels]`   | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
 
 **Example:**
 
@@ -120,7 +120,7 @@ ajs project start [options]
 | `-p, --project <path>`       | Path to the project folder                     |
 | `-e, --env <environment>`    | Environment name                               |
 | `-c, --concurrency <number>` | Number of modules to load in parallel          |
-| `--verbose`                  | Enable verbose logging channels                |
+| `--verbose [=channels]`      | Enable verbose (TRACE level) logging; pass a comma-separated channel list to scope it |
 
 **Example:**
 
@@ -170,7 +170,6 @@ ajs project modules add <modules...> [options]
 | `-m, --mode <mode>`       | Source type: `package` (npm), `git`, `local`, or `dir` (local-folder, no compilation). Defaults to `package`. |
 | `-p, --project <path>`    | Path to the project folder                                       |
 | `-e, --env <environment>` | Environment name                                                 |
-| `--ignoreCache`           | Ignore cached module data and fetch fresh                        |
 
 **Examples:**
 
@@ -204,7 +203,7 @@ ajs project modules rm <modules...> [options]
 |----------------------------|------------------------------------------------|
 | `-p, --project <path>`    | Path to the project folder                     |
 | `-e, --env <environment>` | Environment name                               |
-| `-f, --force`             | Force removal without confirmation             |
+| `-f, --force`             | Continue even if some of the named modules are not found |
 
 **Example:**
 
@@ -281,7 +280,7 @@ ajs project modules install [options]
 |----------------------------|---------------------------------------------------------|
 | `-p, --project <path>`    | Path to the project folder                              |
 | `-e, --env <environment>` | Environment name                                        |
-| `--git <repo>`            | Custom interface repository URL                         |
+| `-g, --git <url>`         | Custom interface repository URL                         |
 
 **Example:**
 

--- a/content/docs/5.cli/3.module.md
+++ b/content/docs/5.cli/3.module.md
@@ -21,9 +21,9 @@ ajs module init <path> [options]
 |----------|------------------------------------------------|
 | `path`   | Directory path where the module will be created |
 
-| Option           | Description                              |
-|------------------|------------------------------------------|
-| `--git <repo>`  | URL of a custom template repository      |
+| Option              | Description                              |
+|---------------------|------------------------------------------|
+| `-g, --git <url>`  | URL of a custom template repository      |
 
 **Examples:**
 

--- a/content/docs/5.cli/4.config.md
+++ b/content/docs/5.cli/4.config.md
@@ -107,4 +107,4 @@ Resetting the configuration removes all custom settings. Any custom interface re
 
 ## See also
 
-- [Configuration](/docs/guides/configuration) — Configuration file reference and options
+- [Configuration](/docs/concepts/configuration) — Configuration file reference and options

--- a/content/docs/5.cli/5.cheat-sheet.md
+++ b/content/docs/5.cli/5.cheat-sheet.md
@@ -52,7 +52,7 @@ navigation:
 |---------------|------------------------------------------------------|
 | `--help`      | Show help for any command                            |
 | `-v, --version` | Display the CLI version                           |
-| `--verbose`   | Enable verbose logging (repeatable for more detail)  |
+| `--verbose [=channels]` | Enable verbose (TRACE level) logging; scope to a comma-separated channel list |
 
 ## Common Dev Options
 

--- a/content/docs/6.community/1.getting-help.md
+++ b/content/docs/6.community/1.getting-help.md
@@ -125,5 +125,5 @@ Found a bug?
 
 Spot something confusing or missing in the docs?
 
-- For small fixes: [Edit the page on GitHub](https://github.com/antelopejs/antelopejs/tree/main/docs)
+- For small fixes: [Edit the page on GitHub](https://github.com/AntelopeJS/antelopejs.com/tree/main/content/docs)
 - For bigger changes: [Open an issue](https://github.com/antelopejs/antelopejs/issues/new) explaining what needs improvement

--- a/content/docs/6.community/3.contribution.md
+++ b/content/docs/6.community/3.contribution.md
@@ -184,7 +184,7 @@ If you've built something useful with Antelopejs, consider turning it into a gen
 - Include example usage in documentation
 - Reference related interfaces when appropriate
 
-For detailed guidance, refer to our [Module documentation](../1.get-started/4.module.md) and [Export Interfaces](../2.interfaces/6.export-interfaces.md) guide.
+For detailed guidance, refer to our [Module documentation](/docs/module-development/creating-a-module) and [Exporting Interfaces](/docs/module-development/exporting-interfaces) guide.
 
 ## Proposing RFCs
 

--- a/content/modules/api.yml
+++ b/content/modules/api.yml
@@ -4,7 +4,7 @@ repo: antelopejs/api
 npm: "@antelopejs/api"
 icon: "/icons/antelope.svg"
 github: https://github.com/AntelopeJS/api
-documentation: https://antelopejs.com/AntelopeJS/api
+documentation: https://github.com/AntelopeJS/api
 category: [Api]
 interface: [api]
 official: true


### PR DESCRIPTION
## Summary

Documentation audit of the site against the current source in the sibling repos (`@antelopejs/core` v1.3.0 CLI/runtime + the `interface-*` packages) and recent commits. Every fix below was verified against source by an independent pass. No prose was rewritten beyond what was factually wrong.

`1.get-started/` was audited and came back clean (install/quick-start/architecture/lifecycle all match the runtime).

## Changes by area

**CLI (`5.cli/`)** — corrected against the live command tree (`src/core/cli/commands/**`):
- Removed a documented-but-nonexistent `modules add --ignoreCache` flag (unused internal field, never registered).
- Fixed `--verbose` everywhere: it's `--verbose [=channels]` (TRACE-level, comma-separated channel filter), not "repeatable for more detail".
- Added the missing `-g` short form to `--git` on `modules install` and `module init`.
- Corrected the `modules remove --force` description (there is no confirmation prompt).
- Repointed a broken config See-also link.

**Guides (`4.guides/`)**:
- `CreateDatabaseSchemaInstance("main")` → `RegisterSchema("main")` (renamed away in interface-database-decorators #5) in the database guide and the full-stack tutorial — code and prose.
- Fixed a broken Configuration link in troubleshooting.

**Concepts (`2.concepts/`)**:
- Documented the v1.3.0 `reloadCommand` field on local/local-folder module sources.
- Trimmed the logging `dateFormat` token list to the six tokens actually implemented (`yyyy MM dd HH mm ss`, UTC).

**Module development (`3.module-development/`)**:
- Replaced a stub-mode error string users were told to grep for (`"Interface not implemented"`, never emitted) with the real message.

**Community + module catalog**:
- Repointed broken intra-doc links (reorganized module-development paths; "edit on GitHub" pointing at a non-existent `docs/` folder in the core repo).
- Fixed `api.yml`'s `documentation` link (was a non-existent site route → GitHub repo, matching siblings).

## Follow-ups (intentionally not in this PR — net-new content)

1. **`data-api` guide doesn't cover the `@Joined` / `@Foreign` relation decorators** (incl. the new cross-schema `schema` param). Documenting them properly needs a new section pulling in `@Listable`/`@Access`/`@Model`; the interface package's own `docs/` already covers them and could be cross-linked.
2. **Module catalog is missing entries** for `interface-email` and `interface-file-storage` (released v0.0.3); `interface-api-util` / `interface-core` are also absent (likely intentional — utility/internal). Not added because the implementation-module npm metadata wasn't available to verify.

> Note: an earlier draft added an `antelopeJs.paths` example to `creating-a-module.md`; it was dropped after source review showed `paths` does not power the `/interface` subpath import (that's handled by `implements` + Node subpath resolution in `resolver.ts`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs the documentation site with the v1.3.0 release of `@antelopejs/core` and its interface packages. No functional code changes are included — every edit is a factual correction verified against the live source.

- **API renames & new fields**: `CreateDatabaseSchemaInstance` → `RegisterSchema` across the database guide and full-stack tutorial; `reloadCommand` field added to both `local` and `local-folder` source types in the configuration reference.
- **CLI accuracy**: Removed phantom `--ignoreCache` flag; fixed `--verbose` to show its optional `[=channels]` argument; corrected `--force` and `--git` descriptions; fixed two broken "See also" links pointing at a non-existent `/docs/guides/configuration` route.
- **Misc fixes**: Corrected stub-mode error message in the testing guide; trimmed `dateFormat` tokens to the six actually implemented; repointed "Edit on GitHub" to the correct docs repo; fixed `api.yml` documentation URL.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes, all verified against source; safe to merge.

Every change corrects a factual inaccuracy against the live v1.3.0 source — removed phantom flags, fixed renamed APIs, corrected error messages, and repaired broken links. No functional code is touched, and the PR description documents the source-verification pass for each area.

content/modules/api.yml — the documentation and github fields now point to the same URL; worth confirming whether the catalog UI distinguishes them or not.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/docs/2.concepts/4.configuration.md | Adds reloadCommand field to both local and local-folder source type examples with accurate inline descriptions; also fixes a missing trailing comma in the local source code block. |
| content/docs/2.concepts/5.logging.md | Trims dateFormat token list from 13 tokens to the 6 actually implemented (yyyy MM dd HH mm ss) and notes UTC formatting; factual correction. |
| content/docs/3.module-development/3.testing.md | Replaces phantom stub-mode error string "Interface not implemented" with the real message emitted by the runtime; consistent across prose, bullet, and warning callout. |
| content/docs/4.guides/2.database.md | Renames CreateDatabaseSchemaInstance → RegisterSchema in import, call site, and section heading/prose; accurate to interface-database-decorators #5. |
| content/docs/4.guides/5.full-stack-tutorial.md | Same CreateDatabaseSchemaInstance → RegisterSchema rename applied consistently across import, call, comments, and trailing explanatory paragraph. |
| content/docs/4.guides/6.troubleshooting.md | Single-line fix: broken See-also link /docs/guides/configuration corrected to /docs/concepts/configuration. |
| content/docs/5.cli/1.introduction.md | Corrects --verbose flag: removes false "repeatable for more detail" description, adds [=channels] optional argument and example usage with comma-separated channel list. |
| content/docs/5.cli/2.project.md | Removes phantom --ignoreCache flag; fixes --verbose in three command tables; adds -g short form to --git on modules install; corrects --force description. |
| content/docs/5.cli/3.module.md | Adds -g short form to --git option on module init; column widths adjusted accordingly. |
| content/docs/5.cli/4.config.md | Single-line fix: broken See-also link /docs/guides/configuration corrected to /docs/concepts/configuration. |
| content/docs/5.cli/5.cheat-sheet.md | Updates --verbose entry in the global options table to match the corrected description from other CLI pages. |
| content/docs/6.community/1.getting-help.md | Fixes "Edit the page on GitHub" link from non-existent antelopejs/antelopejs docs/ folder to the correct AntelopeJS/antelopejs.com content/docs path. |
| content/docs/6.community/3.contribution.md | Replaces two broken relative file-path links with correct absolute documentation routes for module-development pages. |
| content/modules/api.yml | Fixes malformed documentation URL (was site URL with GitHub path appended) to the GitHub repo; now documentation and github fields share the same URL. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[File change detected] --> B{Hot reload?}
    B -- No --> C[Run installCommand]
    B -- Yes --> D{reloadCommand set?}
    D -- Yes --> E[Run reloadCommand]
    D -- No --> C
    C --> F[Module loaded]
    E --> F
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/modules/api.yml:6-7
The `documentation` field now resolves to the same URL as `github`. If the module catalog UI renders a separate "Documentation" link, both entries will point at the repository root rather than any dedicated docs page. Consider pointing `documentation` at the README anchor or the `/readme` path, or leaving it empty/absent until dedicated documentation exists — whichever matches the convention used by the other entries in the catalog.

```suggestion
github: https://github.com/AntelopeJS/api
documentation: https://github.com/AntelopeJS/api#readme
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix broken links in community page..."](https://github.com/antelopejs/antelopejs.com/commit/624a5d3a8fbfd437a9b93f82d20a78f2ff916f45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36472908)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->